### PR TITLE
Add Mentorship Model

### DIFF
--- a/app/models/mentorship.rb
+++ b/app/models/mentorship.rb
@@ -1,0 +1,18 @@
+class Mentorship < ApplicationRecord
+  belongs_to :mentor, class_name: "User"
+  belongs_to :applicant, class_name: "User"
+
+  enum standing: {
+    active: "active",
+    ended: "ended"
+  }
+
+  validates :standing, presence: true
+  validate :mentor_and_applicant_cannot_be_same
+
+  private
+
+  def mentor_and_applicant_cannot_be_same
+    errors.add(:mentor, "cannot be the same as applicant") if mentor == applicant
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,10 @@ class User < ApplicationRecord
   has_many :password_reset_tokens, dependent: :destroy
   has_many :sessions, dependent: :destroy
   has_many :events, dependent: :destroy
+  has_many :mentorship_roles_as_mentor, class_name: "Mentorship", foreign_key: "mentor_id"
+  has_many :mentorship_roles_as_applicant, class_name: "Mentorship", foreign_key: "applicant_id"
+  has_many :mentors, through: :mentorship_roles_as_mentor
+  has_many :applicants, through: :mentorship_roles_as_applicant
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :password, allow_nil: true, length: {minimum: 12}

--- a/db/migrate/20231003222450_create_mentorships.rb
+++ b/db/migrate/20231003222450_create_mentorships.rb
@@ -1,0 +1,23 @@
+class CreateMentorships < ActiveRecord::Migration[7.0]
+  def change
+    create_table "mentorships", id: :binary, force: :cascade do |t|
+      t.binary "mentor_id", limit: 16, null: false, foreign_key: true
+      t.binary "applicant_id", limit: 16, null: false, foreign_key: true
+      t.string :standing, null: false
+      t.datetime :applicant_month_1_email_sent_at
+      t.datetime :applicant_month_2_email_sent_at
+      t.datetime :applicant_month_3_email_sent_at
+      t.datetime :applicant_month_4_email_sent_at
+      t.datetime :applicant_month_5_email_sent_at
+      t.datetime :applicant_month_6_email_sent_at
+      t.datetime :mentor_month_1_email_sent_at
+      t.datetime :mentor_month_2_email_sent_at
+      t.datetime :mentor_month_3_email_sent_at
+      t.datetime :mentor_month_4_email_sent_at
+      t.datetime :mentor_month_5_email_sent_at
+      t.datetime :mentor_month_6_email_sent_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_02_025529) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_222450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,26 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_02_025529) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "mentorships", id: :binary, force: :cascade do |t|
+    t.binary "mentor_id", null: false
+    t.binary "applicant_id", null: false
+    t.string "standing", null: false
+    t.datetime "applicant_month_1_email_sent_at"
+    t.datetime "applicant_month_2_email_sent_at"
+    t.datetime "applicant_month_3_email_sent_at"
+    t.datetime "applicant_month_4_email_sent_at"
+    t.datetime "applicant_month_5_email_sent_at"
+    t.datetime "applicant_month_6_email_sent_at"
+    t.datetime "mentor_month_1_email_sent_at"
+    t.datetime "mentor_month_2_email_sent_at"
+    t.datetime "mentor_month_3_email_sent_at"
+    t.datetime "mentor_month_4_email_sent_at"
+    t.datetime "mentor_month_5_email_sent_at"
+    t.datetime "mentor_month_6_email_sent_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "password_reset_tokens", id: :binary, force: :cascade do |t|

--- a/test/fixtures/mentorships.yml
+++ b/test/fixtures/mentorships.yml
@@ -1,0 +1,35 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+<%# one: %>
+<%#   mentor: one %>
+<%#   applicant: one %>
+<%#   standing: MyString %>
+<%#   applicant_month_1_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_2_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_3_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_4_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_5_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_6_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_1_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_2_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_3_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_4_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_5_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_6_email_sent_at: 2023-10-03 23:24:50 %>
+
+<%# two: %>
+<%#   mentor: two %>
+<%#   applicant: two %>
+<%#   standing: MyString %>
+<%#   applicant_month_1_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_2_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_3_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_4_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_5_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   applicant_month_6_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_1_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_2_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_3_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_4_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_5_email_sent_at: 2023-10-03 23:24:50 %>
+<%#   mentor_month_6_email_sent_at: 2023-10-03 23:24:50 %>

--- a/test/models/mentorship_test.rb
+++ b/test/models/mentorship_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class MentorshipTest < ActiveSupport::TestCase
+  test "should save with valid mentor and applicant" do
+    mentorship = Mentorship.new(mentor: create_mentor, applicant: create_applicant, standing: "active")
+    assert mentorship.save
+  end
+
+  test "should not save with same user as mentor and applicant" do
+    mentor = create_mentor
+    mentorship = Mentorship.new(mentor: mentor, applicant: mentor)
+
+    assert_not mentorship.save
+  end
+
+  test "should be valid with preset standing enum options" do
+    active_mentorship = Mentorship.new(mentor: create_mentor, applicant: create_applicant, standing: "active")
+    assert_equal "active", active_mentorship.standing
+  end
+
+  test "should not be valid with invalid standing enum option" do
+    assert_raises(ArgumentError) { Mentorship.new(mentor: create_mentor, applicant: create_applicant, standing: "invalid_standing") }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,4 +29,20 @@ class ActiveSupport::TestCase
       verified: true
     )
   end
+
+  def create_mentor
+    User.create!(
+      email: "mentor@example.com",
+      password: "Secret1*3*5*",
+      verified: true
+    )
+  end
+
+  def create_applicant
+    User.create!(
+      email: "applicant@example.com",
+      password: "Secret1*3*5*",
+      verified: true
+    )
+  end
 end


### PR DESCRIPTION
#### What's this PR do?

PR Introduces a Mentorships table.
- A Mentorship has two associations with User, one as a mentor and one as an applicant.
- It has a standing attribute to determine whether the mentorship is active or ended.
- Track when a monthly email has been sent to both mentor and applicant for up to 6 months. New row for each month.


##### Background context
n/a


#### Where should the reviewer start?

- `db/migrate/20231003222450_create_mentorships.rb` to check the schema is correct. I had to modify for the ULIDs from users table.
- `app/models/user.rb` to ensure the has_many and has_many through associations are correct. 


#### How should this be manually tested?

n/a


#### Screenshots or Video

n/a


---

#### Migrations

- New table so updates here is same as PR description above. Schema is from Mentorship table outlined [here](https://github.com/goodscary/firstrubyfriend/issues/10)

#### Additional deployment instructions

n/a


#### Additional ENV Vars

n/a