### PR TITLE
Remove country and city from MentorQuestionnaire

### DIFF
--- a/app/models/mentor_questionnaire.rb
+++ b/app/models/mentor_questionnaire.rb
@@ -5,8 +5,6 @@ class MentorQuestionnaire < ApplicationRecord
   validates :name, presence: true
   validates :company_url, presence: true
   validates :year_started_ruby, presence: true
-  validates :country, presence: true
-  validates :city, presence: true
   validates :has_mentored_before, presence: true
   validates :mentoring_reason, presence: true
   validates :preferred_style_career, presence: true

--- a/db/migrate/20231004162014_create_mentor_questionnaires.rb
+++ b/db/migrate/20231004162014_create_mentor_questionnaires.rb
@@ -5,8 +5,6 @@ class CreateMentorQuestionnaires < ActiveRecord::Migration[7.0]
       t.string :name, null: false
       t.string :company_url, null: false
       t.integer :year_started_ruby, null: false
-      t.string :country, null: false
-      t.string :city, null: false
       t.string :twitter_handle
       t.string :github_handle
       t.string :personal_site_url

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,8 +34,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_04_162014) do
     t.string "name", null: false
     t.string "company_url", null: false
     t.integer "year_started_ruby", null: false
-    t.string "country", null: false
-    t.string "city", null: false
     t.string "twitter_handle"
     t.string "github_handle"
     t.string "personal_site_url"

--- a/test/models/mentor_questionnaire_test.rb
+++ b/test/models/mentor_questionnaire_test.rb
@@ -8,8 +8,6 @@ class MentorQuestionnaireTest < ActiveSupport::TestCase
       name: "Andy Croll",
       company_url: "https://example.com",
       year_started_ruby: 2005,
-      country: "UK",
-      city: "Brighton",
       has_mentored_before: true,
       mentoring_reason: "To give back to the community",
       preferred_style_career: true,
@@ -29,16 +27,6 @@ class MentorQuestionnaireTest < ActiveSupport::TestCase
 
   test "year_started_ruby should be present" do
     @mentor_questionnaire.year_started_ruby = nil
-    assert_not @mentor_questionnaire.valid?
-  end
-
-  test "country should be present" do
-    @mentor_questionnaire.country = nil
-    assert_not @mentor_questionnaire.valid?
-  end
-
-  test "city should be present" do
-    @mentor_questionnaire.city = nil
     assert_not @mentor_questionnaire.valid?
   end
 


### PR DESCRIPTION
#### What's this PR do?

Migration to remove city and country fields from MentorQuestionnaire Table. 
These fields are already present in the User model and we can reference it from there.


##### Background context
Discovered these unnecessary field from mentee_questionniare PR https://github.com/goodscary/firstrubyfriend/pull/14#discussion_r1359495914

#### Where should the reviewer start?

- Migration File removes the columns
- Model files removes the presence:true validations
- Test is removed


#### How should this be manually tested?

n/a

#### Screenshots or Video
n/a

---

#### Migrations
n/a


#### Additional deployment instructions

Anything specific we need to worry about when this hits production, do we need to worry about releases, migrations, downtime or significant changes to UI?

n/a
#### Additional ENV Vars

Any additional configuration required in development to run this code locally, **don't include actual secret values here**.