### PR TITLE
Add Under Represented Group details text field on Users table

### DIFF
--- a/db/migrate/20231014174839_add_demographic_underrepresented_group_details_to_users.rb
+++ b/db/migrate/20231014174839_add_demographic_underrepresented_group_details_to_users.rb
@@ -1,0 +1,5 @@
+class AddDemographicUnderrepresentedGroupDetailsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :demographic_underrepresented_group_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_10_180442) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_14_174839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_180442) do
     t.integer "demographic_year_started_ruby"
     t.integer "demographic_year_started_programming"
     t.boolean "demographic_underrepresented_group"
+    t.text "demographic_underrepresented_group_details"
     t.index ["city"], name: "index_users_on_city"
     t.index ["country_code"], name: "index_users_on_country_code"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
#### What's this PR do?

New Migration file to add a new column "underrepresented_group_details" text field to Users model


##### Background context

We figured it was more appropriate for this field to live in the users table than a questionnaire model. https://github.com/goodscary/firstrubyfriend/pull/14#discussion_r1359399008

#### Where should the reviewer start?

- migration file db/migrate/20231014174839_add_demographic_underrepresented_group_details_to_users.rb

#### How should this be manually tested?

n/a


#### Screenshots or Video

A picture is worth a thousand words. WHy not use one?

---

#### Migrations

- Single migration file to add a new text field.


#### Additional deployment instructions

Anything specific we need to worry about when this hits production, do we need to worry about releases, migrations, downtime or significant changes to UI?


#### Additional ENV Vars

Any additional configuration required in development to run this code locally, **don't include actual secret values here**.