### PR TITLE
Remove year started ruby from MentorQuestionnaire Model

### DIFF
--- a/app/models/mentor_questionnaire.rb
+++ b/app/models/mentor_questionnaire.rb
@@ -4,7 +4,6 @@ class MentorQuestionnaire < ApplicationRecord
   validates :respondent_id, presence: true
   validates :name, presence: true
   validates :company_url, presence: true
-  validates :year_started_ruby, presence: true
   validates :has_mentored_before, presence: true
   validates :mentoring_reason, presence: true
 

--- a/db/migrate/20231208034906_remove_year_started_ruby_from_mentor_questionnaires.rb
+++ b/db/migrate/20231208034906_remove_year_started_ruby_from_mentor_questionnaires.rb
@@ -1,0 +1,5 @@
+class RemoveYearStartedRubyFromMentorQuestionnaires < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :mentor_questionnaires, :year_started_ruby, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_01_072200) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_08_034906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,7 +60,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_01_072200) do
     t.binary "respondent_id", null: false
     t.string "name", null: false
     t.string "company_url", null: false
-    t.integer "year_started_ruby", null: false
     t.string "twitter_handle"
     t.string "github_handle"
     t.string "personal_site_url"

--- a/test/models/mentor_questionnaire_test.rb
+++ b/test/models/mentor_questionnaire_test.rb
@@ -7,7 +7,6 @@ class MentorQuestionnaireTest < ActiveSupport::TestCase
       respondent: @user,
       name: "Andy Croll",
       company_url: "https://example.com",
-      year_started_ruby: 2005,
       has_mentored_before: true,
       mentoring_reason: "To give back to the community",
       preferred_style_career: true,
@@ -22,11 +21,6 @@ class MentorQuestionnaireTest < ActiveSupport::TestCase
 
   test "company_url should be present" do
     @mentor_questionnaire.company_url = nil
-    assert_not @mentor_questionnaire.valid?
-  end
-
-  test "year_started_ruby should be present" do
-    @mentor_questionnaire.year_started_ruby = nil
     assert_not @mentor_questionnaire.valid?
   end
 


### PR DESCRIPTION
#### What's this PR do?
Migration to remove `year_started_ruby` from Mentor Questionnaire. 

This column is already in User table as `demographic_year_started_ruby`:
https://github.com/goodscary/firstrubyfriend/blob/1ecc9b3316f956c19983d7e6a12677f07e53dd79/db/schema.rb#L132


##### Background context
This was causing issues continuing with MentorQuestionnaire form as the null constraint wouldn't let me postpone until later. 

#### Where should the reviewer start?

- migration file `db/migrate/20231208034906_remove_year_started_ruby_from_mentor_questionnaires.rb`
- Rest is removal in model validation`app/models/mentor_questionnaire.rb` and test `test/models/mentor_questionnaire_test.rb`


#### How should this be manually tested?

If there's specific QA areas to focus on?


#### Screenshots or Video

A picture is worth a thousand words. WHy not use one?


---

#### Migrations

see above


#### Additional deployment instructions

n/a

#### Additional ENV Vars
n/a