### PR TITLE
Add Languages as nested_form fields.

### DIFF
--- a/app/controllers/mentor_questionnaires_controller.rb
+++ b/app/controllers/mentor_questionnaires_controller.rb
@@ -7,6 +7,7 @@ class MentorQuestionnairesController < ApplicationController
       redirect_to edit_mentor_questionnaire_path(@user.mentor_questionnaire)
     else
       @mentor_questionnaire = MentorQuestionnaire.new
+      @user.user_languages.build
     end
   end
 
@@ -22,10 +23,12 @@ class MentorQuestionnairesController < ApplicationController
   end
 
   def edit
+    @user = @mentor_questionnaire.respondent
   end
 
   def update
     if @mentor_questionnaire.update(mentor_questionnaire_params)
+      update_user_if_needed
       redirect_to root_path, notice: "Your Mentor Questionnaire has been updated."
     else
       render :edit, status: :unprocessable_entity
@@ -50,7 +53,10 @@ class MentorQuestionnairesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:demographic_year_started_ruby)
+    params.require(:user).permit(
+      :demographic_year_started_ruby,
+      user_languages_attributes: [:language_id, :id, :_destroy]
+    )
   end
 
   def set_user
@@ -59,5 +65,11 @@ class MentorQuestionnairesController < ApplicationController
 
   def set_mentor_questionnaire
     @mentor_questionnaire = @user.mentor_questionnaire
+  end
+
+  def update_user_if_needed
+    if user_params.present? && @user.attributes.slice(*user_params.keys) != user_params
+      @user.update(user_params)
+    end
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,4 +1,7 @@
 class Language < ApplicationRecord
+  include ULID::Rails
+  ulid :id, auto_generate: true
+
   has_many :user_languages
   has_many :users, through: :user_languages
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   has_many :user_languages
   has_many :languages, through: :user_languages
 
+  accepts_nested_attributes_for :user_languages
+
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :password, allow_nil: true, length: {minimum: 12}
   validates :password, not_pwned: {message: "might easily be guessed"}

--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -1,4 +1,9 @@
 class UserLanguage < ApplicationRecord
+  include ULID::Rails
+  ulid :id, auto_generate: true
+  ulid :user_id
+  ulid :language_id
+
   belongs_to :user
   belongs_to :language
 

--- a/app/views/mentor_questionnaires/_form.html.erb
+++ b/app/views/mentor_questionnaires/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @mentor_questionnaire, url: mentor_questionnaires_path) do |form| %>
+<%= form_with(model: @mentor_questionnaire) do |form| %>
   <div class="px-4 py-2 sm:p-8 space-y-8">
     <% if @mentor_questionnaire.errors.any? %>
       <div>
@@ -22,11 +22,20 @@
       <%= form.text_field :company_url %>
     </div>
 
-    <div class="flex flex-col">
-      <%= label_tag 'user[demographic_year_started_ruby]', "Year you started programming in Ruby*" %>
-      <p>Some folk will want to speak to someone who's within touching distance of the beginning of their careers, some will want grizzled veterans.</p>
-      <%= select_tag 'user[demographic_year_started_ruby]', options_for_select((1993..Date.today.year).to_a.reverse, selected: @user.demographic_year_started_ruby), include_blank: true %>
-    </div>
+    <%= fields_for :user, @user do |user_form| %>
+      <div class="flex flex-col">
+        <%= user_form.label :demographic_year_started_ruby, "Year you started programming in Ruby*" %>
+        <%= user_form.select :demographic_year_started_ruby, options_for_select((1993..Date.today.year).to_a.reverse, selected: @user.demographic_year_started_ruby), include_blank: true %>
+      </div>
+
+      <%= user_form.fields_for :user_languages do |fl| %>
+        <div>
+          <%= fl.label :language_id %>
+          <%= fl.collection_select :language_id, Language.all, :id, :english_name %>
+        </div>
+      <% end %>
+    <% end %>
+
 
     <div class="flex flex-col">
       <%= form.label :twitter_handle, "Twitter?" %>

--- a/test/controllers/mentor_questionnaires_controller_test.rb
+++ b/test/controllers/mentor_questionnaires_controller_test.rb
@@ -11,6 +11,13 @@ class MentorQuestionnairesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create mentor questionnaire" do
+    english_language = Language.create!(
+      iso639_alpha3: "eng",
+      iso639_alpha2: "",
+      english_name: "English",
+      french_name: "anglais",
+      local_name: nil
+    )
     assert_difference("MentorQuestionnaire.count") do
       post mentor_questionnaires_url, params: {
         mentor_questionnaire: {
@@ -21,7 +28,10 @@ class MentorQuestionnairesControllerTest < ActionDispatch::IntegrationTest
           preferred_style_career: true,
           preferred_style_code: false
         },
-        user: {demographic_year_started_ruby: 2005}
+        user: {
+          demographic_year_started_ruby: 2005,
+          language: english_language
+        }
       }
     end
 


### PR DESCRIPTION
#### What's this PR do?

Description of the high level functionality and reason for introduction of this feature.
- Adds language field to mentor questionnaire. (What languages do you speak?)
- Made user demographic field to also be as nested form
- Added ULID to models.

##### Background context
Subtask 2 from https://github.com/goodscary/firstrubyfriend/issues/23

#### Where should the reviewer start?

n/a

#### How should this be manually tested?
1. Go to /mentor_questionnaires/new
2. Fill in the form. Mentor Questionnaire, UserLanguage, and User attribute should get saved

If there's specific QA areas to focus on?
n/a

#### Screenshots or Video

n/a

---

#### Migrations

Broad detail of changes to the schema
n/a

#### Additional deployment instructions

Anything specific we need to worry about when this hits production, do we need to worry about releases, migrations, downtime or significant changes to UI?


#### Additional ENV Vars

Any additional configuration required in development to run this code locally, **don't include actual secret values here**.