### PR TITLE
Add Country and City questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "rails", github: "rails/rails", branch: "main"
 gem "authentication-zero"
 gem "bootsnap", require: false # Reduces boot times through caching; required in config/boot.rb
 gem "bcrypt" # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
+gem "country_select"
+gem "geocoder"
 # gem "image_processing", "~> 1.2" # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "importmap-rails" # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "kredis" # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
@@ -24,7 +26,6 @@ gem "omniauth-github"
 # Provides a mitigation against CVE-2015-9284 [https://github.com/cookpad/omniauth-rails_csrf_protection]
 gem "omniauth-rails_csrf_protection"
 gem "ulid-rails"
-
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,12 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    countries (6.0.1)
+      unaccent (~> 0.3)
+    country_select (9.0.0)
+      countries (> 5.0, < 7.0)
     crass (1.0.6)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -132,6 +137,9 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -325,6 +333,7 @@ GEM
       activesupport (>= 5.2)
       base32-crockford (~> 0.1)
       ulid (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     useragent (0.16.10)
@@ -354,7 +363,9 @@ DEPENDENCIES
   bcrypt
   bootsnap
   capybara
+  country_select
   debug
+  geocoder
   importmap-rails
   kredis
   omniauth-github

--- a/app/controllers/mentor_questionnaires_controller.rb
+++ b/app/controllers/mentor_questionnaires_controller.rb
@@ -54,6 +54,8 @@ class MentorQuestionnairesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
+      :city,
+      :country_code,
       :demographic_year_started_ruby,
       user_languages_attributes: [:language_id, :id, :_destroy]
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,4 +50,12 @@ class User < ApplicationRecord
   after_update if: [:verified_previously_changed?, :verified?] do
     events.create! action: "email_verified"
   end
+
+  geocoded_by :address, latitude: :lat, longitude: :lng
+
+  after_validation :geocode, if: ->(obj) { obj.city_changed? || obj.country_code_changed? }
+
+  def address
+    [city, country_code].compact.join(", ")
+  end
 end

--- a/app/views/mentor_questionnaires/_form.html.erb
+++ b/app/views/mentor_questionnaires/_form.html.erb
@@ -24,6 +24,18 @@
 
     <%= fields_for :user, @user do |user_form| %>
       <div class="flex flex-col">
+        <%= user_form.label :city, "City*" %>
+        <%= user_form.text_field :city, class: "form-input" %>
+      </div>
+
+      <div class="flex flex-col">
+        <%= user_form.label :country_code, "Country*" %>
+        <%= user_form.country_select :country_code,
+            { include_blank: "Select a country" },
+            { class: "form-select" } %>
+      </div>
+
+      <div class="flex flex-col">
         <%= user_form.label :demographic_year_started_ruby, "Year you started programming in Ruby*" %>
         <%= user_form.select :demographic_year_started_ruby, options_for_select((1993..Date.today.year).to_a.reverse, selected: @user.demographic_year_started_ruby), include_blank: true %>
       </div>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  units: :mi,                 # :km for kilometers or :mi for miles
+  distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)


### PR DESCRIPTION
#### What's this PR do?

- Add City and Country question fields to the Mentor Questionnaire.
- Used geocoder and country_select gems to achieve this. 


##### Background context

Subtask 3 from https://github.com/goodscary/firstrubyfriend/issues/23

#### Where should the reviewer start?

- User model adds geocoder validation. Implementation is straight from their [readme](https://github.com/alexreisner/geocoder). Do we want a different approach?
- Country select field in the MentionQuestionnaire form. Do we want a different approach?

#### How should this be manually tested?

- Sign up for an account
- Complete the form and check the lat and lng fields are updated:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/5cfa57bc-078b-41da-8a20-b38ec053375f">


---

#### Migrations
n/a

#### Additional deployment instructions

n/a


#### Additional ENV Vars

n/a